### PR TITLE
ツゥーンシェーダが適切に動かない問題の修正

### DIFF
--- a/ProgramWs1/Assets/toonUS.shader
+++ b/ProgramWs1/Assets/toonUS.shader
@@ -68,7 +68,7 @@
 					half NL = dot(N, L) * 0.5 + 0.5;
 
 					float4 col;
-					col.agb = albedo.rgb * _LightColor0.rgb * tex2D(_RampTex, fixed2(NL, 1.0)).rgb;
+					col.rgb = albedo.rgb * _LightColor0.rgb * tex2D(_RampTex, fixed2(NL, 1.0)).rgb;
 					col.a = 0;
 					UNITY_APPLY_FOG(i.fogCoord, col);
 					return col;


### PR DESCRIPTION
出力先が「rgb」ではなく「agb」となっていて、赤成分に値が入れられていませんでした。